### PR TITLE
Added catkit.api to setup.py for installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('LICENSE') as f:
 setup(
     name='CatKit',
     version='0.1.0',
-    packages=['catkit'],
+    packages=['catkit', 'catkit.api'],
     author='Jacob Boes',
     author_email='jrboes@stanford.edu',
     license=license,


### PR DESCRIPTION
Setuptools wants you to list every directory with python files that you want to include in the installation.