### PR TITLE
Split only after the first underscore ('_') in structure folder name …

### DIFF
--- a/catkit/hub/folderreader.py
+++ b/catkit/hub/folderreader.py
@@ -257,7 +257,7 @@ class FolderReader:
 
     def read_bulk(self, root, files):
 
-        self.metal, self.crystal = root.split('/')[-1].split('_')
+        self.metal, self.crystal = root.split('/')[-1].split('_', 1)
 
         print('------------------------------------------------------')
         print('                    Surface:  {}'.format(self.metal))


### PR DESCRIPTION
…and preserve the rest.

This is useful the structure name itself is more complex (e.g. `A_a_225` instead of `fcc`).