### PR TITLE
pawprint documentation update

### DIFF
--- a/catkit/pawprint/generator.py
+++ b/catkit/pawprint/generator.py
@@ -49,15 +49,15 @@ class Fingerprinter():
 
         Parameters
         ----------
-        atoms : object
+        atoms : Atoms object
             Structure to return parameters for, contains n atoms.
-        parameters : list of str (m,)
+        parameters : list of str (M,)
             Seed parameters to use for atom specific parameter
             generation.
 
         Returns
         -------
-        atoms_parameters : ndarray (m, n)
+        atoms_parameters : ndarray (M, N)
             General chemical properties specific to this atoms object
             and list of seed parameters.
         """
@@ -70,21 +70,24 @@ class Fingerprinter():
 
         return atoms_parameters
 
-    def get_fp(self, parameters_list, operation_list):
+    def get_fp(self, parameters, operation_list):
         """Return the fingerprints for a list of images of single atoms
-        object for the given parameters.
+        object for the given parameters. Convolutions will be performed for
+        specific operations if the parameters is provided as a list of lists.
 
         Parameters
         ----------
-        parameters : list of str
+        parameters : list of str | list of lists (M,)
             Names of seeding parameters available in the parameters
-            database.
-        operation_list : list of functions
+            database. If a list lists is provided, the number of lists
+            must be equal to the number of operations.
+        operation_list : list of func | str (M,)
             A list of operation functions to produce the fingerprints from.
+            The names (str) of operations functions can also be used.
 
         Returns
         -------
-        fingerprints : ndarray (n, m)
+        fingerprints : ndarray (N, X)
             Fingerprints for the images produced from the provided
             seed parameters.
         """
@@ -108,12 +111,12 @@ class Fingerprinter():
                 if isinstance(operation, str):
                     operation = getattr(operations, operation)
 
-                if all(isinstance(pl, list) for pl in parameters_list):
-                    atoms_parameters = self._get_atoms_parameters(atoms,
-                            parameters_list[j])
+                if all(isinstance(pl, list) for pl in parameters):
+                    atoms_parameters = self._get_atoms_parameters(
+                        atoms, parameters[j])
                 else:
-                    atoms_parameters = self._get_atoms_parameters(atoms,
-                            parameters_list)
+                    atoms_parameters = self._get_atoms_parameters(
+                        atoms, parameters)
 
                 fingerprint = _generate_fingerprint(
                     operation,
@@ -142,16 +145,16 @@ def _generate_fingerprint(
         A list of operation functions to produce the fingerprints from.
     atoms : object
         Atomic structure to generate fingerprint for.
-    atoms_parameters : ndarray (n, m)
+    atoms_parameters : ndarray (N, M)
         General chemical properties specific to this atoms object
         and list of seed parameters.
-    connectivity : ndarray (n, n)
+    connectivity : ndarray (N, N)
         Estimated connectivity matrix where n is the number
         of atoms in the atoms-object.
 
     Returns
     -------
-    fingerprint : ndarray (m,)
+    fingerprint : ndarray (M,)
         Fingerprint produced from a given operation and seed parameters.
     """
     fingerprint = operation(
@@ -179,7 +182,7 @@ def get_connectivity(atoms, method=None):
 
     Returns
     -------
-    connectivity : ndarray (n, n)
+    connectivity : ndarray (N, N)
         Estimated connectivity matrix where n is the number
         of atoms in the atoms-object.
     """

--- a/catkit/pawprint/operations.py
+++ b/catkit/pawprint/operations.py
@@ -86,17 +86,20 @@ def local_ads_metal_fp(
         connectivity=None,
         fuse=False):
     """Sum of the differences in properties of the atoms in the
-       metal-adsorbate interface"""
+    metal-adsorbate interface
+    """
     bond_index = np.where(atoms.get_tags() == -1)[0]
     fp = np.empty([len(atoms_parameters), len(bond_index)])
+
     for i, bi in enumerate(bond_index):
         bonded_ap = atoms_parameters[:, np.where(connectivity[bi] == 1)[0]]
         fp[:, i] = np.mean(bonded_ap -
-                atoms_parameters[:, bi].reshape(-1, 1), axis=1)
+                           atoms_parameters[:, bi].reshape(-1, 1), axis=1)
+
     if not fuse:
         return fp.reshape(-1)
     else:
-       return fp.sum(axis=1)
+        return fp.sum(axis=1)
 
 
 def derived_fp(
@@ -108,21 +111,23 @@ def derived_fp(
         n_1=None,
         n_2=None,
         op=None):
-    """
-    NOTE : This is a work in progress. I'll redesign the whole thing to allow
-           for arithmetic manipulation of two fingerprints.
-       Given two fingerprints vector, it will perform arithmetic operation to
-       design new fingerprints.
+    """NOTE : This is a work in progress. I'll redesign the whole thing to allow
+    for arithmetic manipulation of two fingerprints.
 
-       Available operations:
-           add : adds two fingerprints of equal length raised to their given
-                 power.
-           subtract : subtracts two fingerprints of equal length raised to
-                      their given power.
-           mulltiply : multiply two fingerprints of equal length raised to
-                       their given power.
-           divide : divide two fingerprints of equal length raised to their
-                    given power."""
+    Given two fingerprints vector, it will perform arithmetic operation to
+    design new fingerprints.
+
+    Parameters
+    ----------
+    op : str ('add' | 'subtract' | 'divide' | 'multiply')
+        add - Adds two fingerprints of equal length raised to their given power
+        subtract - subtracts two fingerprints of equal length raised to
+                   their given power
+        mulltiply - multiply two fingerprints of equal length raised to
+                    their given power
+        divide - divide two fingerprints of equal length raised to their
+                 given power
+    """
     if op == 'add':
         return fp_1 ** n_1 + fp_2 ** n_2
     elif op == 'subtract':


### PR DESCRIPTION
- Sphinx compliant docstrings for autodoc generation
- Some PEP formatting
- Changed a variable name from `parameters_list` back to `parameters` so current examples will continue to function.