### PR TITLE
Fixed several bugs an nuisances in cathub organize script

### DIFF
--- a/catkit/hub/cli.py
+++ b/catkit/hub/cli.py
@@ -67,12 +67,14 @@ def ase(dbuser, dbpassword, args, gui):
 @click.option(
     '--skip-folders',
     default='',
+    show_default=True,
     help="""subfolders not to read, given as the name of a single folder,
     or a string with names of more folders seperated by ', '""")
 @click.option(
     '--energy-limit',
-    default=5,
-    help="""Limit for accepted absolute reaction energies""")
+    default=5.0,
+    show_default=True,
+    help="""Bounds for accepted absolute reaction energies in eV""")
 @click.option('--goto-reaction',
               help="""name of reaction folder to skip ahead to""")
 def folder2db(folder_name, userhandle, debug, energy_limit, skip_folders,
@@ -147,6 +149,7 @@ publication_columns = [
     '-q',
     default={},
     multiple='True',
+    show_default=True,
     help="""Make a selection on one of the columns:
     {0}\n Examples: \n -q chemicalComposition=~Pt for surfaces containing Pt
     \n -q reactants=CO for reactions with CO as a reactants"""
@@ -188,6 +191,7 @@ def reactions(columns, n_results, queries):
     '-q',
     default={},
     multiple=True,
+    show_default=True,
     help="""Make a selection on one of the columns:
     {0}\n Examples: \n -q: \n title=~Evolution \n authors=~bajdich
     \n year=2017""".format(publication_columns))
@@ -407,6 +411,14 @@ def connect(user):
     default='facet',
     help="Manually specify a facet names.")
 @click.option(
+    '-d', '--gas-dir',
+    type=str,
+    default='',
+    show_default=True,
+    help="Specify a folder where gas-phase molecules"
+    " for calculating adsorption energies are located."
+        )
+@click.option(
     '-g', '--max-density-gas',
     type=float,
     default=0.002,
@@ -432,7 +444,7 @@ def connect(user):
 @click.option(
     '-m', '--max-energy',
     type=float,
-    default=10.,
+    default=100.,
     show_default=True,
     help="Maximum absolute energy (in eV) that is considered.",)
 @click.option(
@@ -473,6 +485,15 @@ def connect(user):
     show_default=True,
     help="Store intermediate filetype as traj"
     "instead of json files")
+@click.option(
+    '-u', '--use-cache',
+    type=bool,
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="When set the script will structures"
+    " will be cached between runs in a file named"
+    " <FOLDER_NAME>.cache.pckl")
 @click.option(
     '-v', '--verbose',
     is_flag=True,


### PR DESCRIPTION
Here are a bunch of fixes that give people trying to upload their data a hard time. Specifically:

- standard energy window for recognized reaction energies is raised from +/-10 eV to +/-100 eV
- CLI flags show default in help page
- `cathub organize` now has additional optional flag `-d` or `--gas-dir` to include additional directory for gas phase references. Saves the user from copying gas phase molecules around
- the use of the `*.cache.pckl` file is now optional and off by default because more often than not it would confuse user when not deleted. It can still be useful for accelerating multiple runs from the same set of large (say OUTCAR) files with `-u` or `--use-gas`
- when `cathub organize` does not specify facet `-f` the script will try to glean Miller indices from path: but not it will also name the folder accordingly.

That's it. Would be nice if it could make its way into CatKit (& suncat & sherlock cluster soon).

Thanks and have nice weekend.
