### PR TITLE
Fix cell/pbc attribute errors due to ASE changes

### DIFF
--- a/catkit/flow/fwase.py
+++ b/catkit/flow/fwase.py
@@ -48,7 +48,7 @@ def get_potential_energy(
     images[0].info = atoms.info
     for image in images:
         image.constraints = atoms.constraints
-        image._pbc = atoms.pbc
+        image.pbc = atoms.pbc
 
     return fwio.atoms_to_encode(images)
 
@@ -105,7 +105,7 @@ def catflow_relaxation(atoms=None, calculator_name=None, parameters=None):
     # Moneky patch for constraints and pbc conservation.
     for image in images:
         image.constraints = atoms.constraints
-        image._pbc = atoms.pbc
+        image.pbc = atoms.pbc
 
     with db.Connect() as dbflow:
         dbflow.update_bulk_entry(images)

--- a/catkit/gratoms.py
+++ b/catkit/gratoms.py
@@ -149,7 +149,7 @@ class Gratoms(ase.Atoms):
 
     def copy(self):
         """Return a copy."""
-        atoms = self.__class__(cell=self._cell, pbc=self._pbc, info=self.info)
+        atoms = self.__class__(cell=self.cell, pbc=self.pbc, info=self.info)
 
         atoms.arrays = {}
         for name, a in self.arrays.items():
@@ -212,7 +212,7 @@ class Gratoms(ase.Atoms):
                 except IndexError:
                     pass
 
-        atoms = self.__class__(cell=self._cell, pbc=self._pbc, info=self.info,
+        atoms = self.__class__(cell=self.cell, pbc=self.pbc, info=self.info,
                                celldisp=self._celldisp)
 
         atoms.arrays = {}
@@ -315,7 +315,7 @@ class Gratoms(ase.Atoms):
         if isinstance(m, int):
             m = (m, m, m)
 
-        for x, vec in zip(m, self._cell):
+        for x, vec in zip(m, self.cell):
             if x != 1 and not vec.any():
                 raise ValueError(
                     'Cannot repeat along undefined lattice vector')
@@ -334,7 +334,7 @@ class Gratoms(ase.Atoms):
             for m1 in range(m[1]):
                 for m2 in range(m[2]):
                     i1 = i0 + n
-                    positions[i0:i1] += np.dot((m0, m1, m2), self._cell)
+                    positions[i0:i1] += np.dot((m0, m1, m2), self.cell)
                     i0 = i1
                     if m0 + m1 + m2 != 0:
                         self._graph = nx.disjoint_union(self._graph, cgraph)
@@ -342,6 +342,6 @@ class Gratoms(ase.Atoms):
         if self.constraints is not None:
             self.constraints = [c.repeat(m, n) for c in self.constraints]
 
-        self._cell = np.array([m[c] * self._cell[c] for c in range(3)])
+        self.cell = np.array([m[c] * self.cell[c] for c in range(3)])
 
         return self


### PR DESCRIPTION
Recently ASE changed the Atoms object `cell` (and `pbc`) attributes from being simple arrays to more complex objects. One consequence of this is that `Atoms._cell` is no longer the place to find the cell. These changes make CatKit correctly look for the unit cell in `Atoms.cell`. As far as I can tell, CatKit continues to work with the changes in this PR, even though `Atoms.cell` is no longer a numpy array. If you want your `Gratoms.cell` attribute to continue being a numpy array, consider doing something like `np.asarray(some_ase_atoms_object.cell)`.

More generally, it is unwise to access object attributes with a leading underscore unless they are yours, and even then access should be limited. The ASE `Atoms.cell` and `Atoms.pbc` attributes are the "public interface" to the unit cell and periodic boundary condition information, whereas `Atoms._cell` and `Atoms._pbc` was (and no longer is) where those data were stored. Looking through this code, I see a lot of instances of `self._foo`. This access pattern is inconsistent with the message you are sending ("this is a private attribute, do not touch!") by putting an underscore in front of the name.