### PR TITLE
Fix warning for incorrect compare with literal

### DIFF
--- a/catkit/gen/adsorption.py
+++ b/catkit/gen/adsorption.py
@@ -514,7 +514,7 @@ class Builder(AdsorptionSites):
             raise ValueError('Specify the index of atom to bond.')
 
         elif len(bonds) == 1:
-            if index is -1:
+            if index == -1:
                 slab = []
                 for i, _ in enumerate(self.get_symmetric_sites()):
                     slab += [self._single_adsorption(


### PR DESCRIPTION
There is a SyntaxWarning generated by a compare in the adsorption.py:

```
catkit/gen/adsorption.py:517: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

This PR uses a correct compare, and silences the warning