### PR TITLE
Update sklearn -> scikit-learn package name to avoid deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.14
 networkx>=2.1
 spglib>=1.10
 scipy>=0.1
-sklearn
+scikit-learn
 matplotlib>=2.2
 future>=0.16
 fireworks>=1.7


### PR DESCRIPTION
Fix deprecation warning on install due to old package name

```
ERROR: Command errored out with exit status 1:
     command: /home/alainr/tmp3/env3/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-3c2frpe3/sklearn_54ea6a07ad11452aad0b7eea08dcc360/setup.py'"'"'; __file__='"'"'/tmp/pip-install-3c2frpe3/sklearn_54ea6a07ad11452aad0b7eea08dcc360/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-z7sksjbj
         cwd: /tmp/pip-install-3c2frpe3/sklearn_54ea6a07ad11452aad0b7eea08dcc360/
    Complete output (18 lines):
    The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
    rather than 'sklearn' for pip commands.
```