### PR TITLE
Fix 'inhomogeneous shape' error topology on adsorption

### DIFF
--- a/catkit/gen/adsorption.py
+++ b/catkit/gen/adsorption.py
@@ -57,8 +57,8 @@ class AdsorptionSites():
 
         self.coordinates = np.array(self.coordinates)
         self.connectivity = np.array(self.connectivity, dtype=int)
-        self.r1_topology = np.array(self.r1_topology)
-        self.r2_topology = np.array(self.r2_topology)
+        self.r1_topology = np.array(self.r1_topology, dtype=object)
+        self.r2_topology = np.array(self.r2_topology, dtype=object)
         self.frac_coords = np.dot(self.coordinates, np.linalg.pinv(slab.cell))
         self.slab = slab
 
@@ -91,7 +91,7 @@ class AdsorptionSites():
     def get_topology(self, unique=True):
         """Return the indices of adjacent surface atoms."""
         topology = [self.index[top] for top in self.r1_topology]
-        topology = np.array(topology)
+        topology = np.array(topology, dtype=object)
         if unique:
             sel = self.get_symmetric_sites()
         else:

--- a/catkit/gen/adsorption.py
+++ b/catkit/gen/adsorption.py
@@ -514,7 +514,7 @@ class Builder(AdsorptionSites):
             raise ValueError('Specify the index of atom to bond.')
 
         elif len(bonds) == 1:
-            if index is -1:
+            if index == -1:
                 slab = []
                 for i, _ in enumerate(self.get_symmetric_sites()):
                     slab += [self._single_adsorption(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.14
 networkx>=2.1
 spglib>=1.10
 scipy>=0.1
-sklearn
+scikit-learn
 matplotlib>=2.2
 future>=0.16
 fireworks>=1.7


### PR DESCRIPTION
numpy now treats initialising inhomogeneous shape arrays by throwing an exception. This means that the topology code in the adsorption module now throws an exception with the sample code in the documentation.

```
Exception has occurred: ValueError
setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (457,) + inhomogeneous part.
```

By treating passing dtype=object, numpy will allow the creation of inhomogeneous shaped arrays - This PR fixes the module and allows the sample code to run successfully,