### PR TITLE
Update for newer versions of Python, NumPy

### DIFF
--- a/catkit/gen/__init__.py
+++ b/catkit/gen/__init__.py
@@ -2,7 +2,7 @@
 # (see accompanying license files for details).
 """Catalysis Generator."""
 
-from collections import MutableMapping
+from collections.abc import MutableMapping
 import numpy as np
 import ase
 

--- a/catkit/gen/adsorption.py
+++ b/catkit/gen/adsorption.py
@@ -514,7 +514,7 @@ class Builder(AdsorptionSites):
             raise ValueError('Specify the index of atom to bond.')
 
         elif len(bonds) == 1:
-            if index is -1:
+            if index == -1:
                 slab = []
                 for i, _ in enumerate(self.get_symmetric_sites()):
                     slab += [self._single_adsorption(

--- a/catkit/gen/adsorption.py
+++ b/catkit/gen/adsorption.py
@@ -57,8 +57,8 @@ class AdsorptionSites():
 
         self.coordinates = np.array(self.coordinates)
         self.connectivity = np.array(self.connectivity, dtype=int)
-        self.r1_topology = np.array(self.r1_topology)
-        self.r2_topology = np.array(self.r2_topology)
+        self.r1_topology = np.array(self.r1_topology, dtype=object)
+        self.r2_topology = np.array(self.r2_topology, dtype=object)
         self.frac_coords = np.dot(self.coordinates, np.linalg.pinv(slab.cell))
         self.slab = slab
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ numpy>=1.14
 networkx>=2.1
 spglib>=1.10
 scipy>=0.1
-sklearn
 matplotlib>=2.2
 future>=0.16
 fireworks>=1.7


### PR DESCRIPTION
This PR fixes a few issues that CatKit has with newer versions of Python and NumPy

- Move the location of MutableMappings
- Ensure that NumPy creates a non-rectangular array with provided with a sequence of sequences

I also fixed a few other bugs:
- Using `is` to test for equality
- Installing "sklearn," which is a [placeholder for scikit-learn](https://pypi.org/project/sklearn/)