### PR TITLE
Merging layer_type 'trim' and 'sym' and fixing slab center atoms

### DIFF
--- a/catkit/gen/surface.py
+++ b/catkit/gen/surface.py
@@ -437,9 +437,7 @@ class SlabGenerator(object):
                 top_fix = tags >= (tags.min() + self.fixed)
 
                 fixed = np.logical_and(bottom_fix, top_fix)
-                print(fixed)
                 constraints = ase.constraints.FixAtoms(mask = fixed)
-                print(constraints)
                 slab.set_constraint(constraints)
 
         self.slab = slab


### PR DESCRIPTION
Created a new layer_type 'symtrim': a junction of 'trim' and 'sym', allowing greater precision when building a symmetric slab. Added a new 'fixed' type named 'center', for fixing slab center layers.