### PR TITLE
Rename method get_pointgroup to get_point_group

### DIFF
--- a/catkit/gen/symmetry.py
+++ b/catkit/gen/symmetry.py
@@ -104,7 +104,7 @@ class Symmetry():
 
         return rotations, translations
 
-    def get_pointgroup(self, check_laue=False):
+    def get_point_group(self, check_laue=False):
         """Return the point group operations of a systems.
 
         Parameters


### PR DESCRIPTION
A bug in defining the function's name, it is only used as get_point_group in surface.py

https://github.com/SUNCAT-Center/CatKit/blob/38ca0c8dc87c4be67b34e03a74e57ad29c85b902/catkit/gen/surface.py#L537